### PR TITLE
Read README.rst into long_description instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="django-deployer",
     version="0.1.0",
     description="Django deployment utility for popular PaaS providers",
-    long_description=open('README.md').read(),
+    long_description=open('README.rst').read(),
     author="Nate Aune",
     author_email="nate@appsembler.com",
     url="https://github.com/natea/django-deployer",


### PR DESCRIPTION
setup.py relied on README.md for long_description, the switch to README.rst requires this change
